### PR TITLE
Update protocol version check to use >= instead of ==

### DIFF
--- a/konnect/protocols.py
+++ b/konnect/protocols.py
@@ -122,7 +122,7 @@ class Konnect(LineReceiver):
     self.name = packet.get("deviceName", "unnamed")
     self.device = packet.get("deviceType", "unknown")
 
-    if packet.get("protocolVersion") == Packet.PROTOCOL_VERSION:
+    if packet.get("protocolVersion") >= Packet.PROTOCOL_VERSION:
       info("Starting client SSL (but I'm the server TCP socket)")
       self.transport.startTLS(self.factory.options, False)
       info("Socket succesfully established an SSL connection")


### PR DESCRIPTION
The current code already rejects older protocol versions with the message "uses an old protocol version, this won't work". Changing to >= comparison allows backward compatibility with current protocol version while also supporting future versions, making the implementation more future-proof.

Tested this with latest KDE Connect App from Play Store (v1.33.2) and latest kdeconnectd version from Fedora (kdeconnect.daemon 24.12.3). Everything seems to work flawlessly.